### PR TITLE
Fixed redirection with params

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,6 +10,10 @@ let simpleRedirects = ["www.mediapart.fr", "www.arretsurimages.net"]
 let isSimpleRedirect = simpleRedirects.inArray(host)
 
 if (isSimpleRedirect) {
-    window.location.replace(redirectHost + window.location)
+    window.location.replace(redirectHost + removeQueryString(window.location.toString()))
+}
+
+function removeQueryString(url) {
+    return url.split('?')[0];
 }
 


### PR DESCRIPTION
The BNF websites apparently save the URL without query strings. Adding any query string will cause a display like the user is not connected.

This fix removes any query strings both for Mediapart and Arrêt sur Images URLs.

Fixes #1