### PR TITLE
Fix issue #3 "Connection issues with Mediapart and Arrêt sur Images"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,17 +9,9 @@
         "48": "icon.png"
     },
     "permissions": [
-      "tabs"
+      "*://www.mediapart.fr/*", "*://www.arretsurimages.net/*", "*://*.bnf.idm.oclc.org/*", "*://bnf.idm.oclc.org/*", "*://idppub.bnf.fr/*", "*://authentification.bnf.fr/*", "activeTab"
     ],
-    "content_scripts": [
-        {
-            "matches": [
-                "https://www.mediapart.fr/*",
-                "https://www.arretsurimages.net/*"
-            ],
-            "js": [
-                "script.js"
-            ]
-        }
-    ]
+    "background": {
+	"scripts": ["script.js"]
+    }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,9 @@
     "icons": {
         "48": "icon.png"
     },
+    "permissions": [
+      "tabs"
+    ],
     "content_scripts": [
         {
             "matches": [

--- a/script.js
+++ b/script.js
@@ -6,11 +6,50 @@ let redirectHost = "https://bnf.idm.oclc.org/login?url="
 let host = window.location.host;
 let path = window.location.pathname;
 
-let simpleRedirects = ["www.mediapart.fr", "www.arretsurimages.net"]
-let isSimpleRedirect = simpleRedirects.inArray(host)
+//let simpleRedirects = ["www.mediapart.fr", "www.arretsurimages.net"]
 
-if (isSimpleRedirect) {
-    window.location.replace(redirectHost + removeQueryString(window.location.toString()))
+/*
+    Previous method failed because autologin must occur before
+    navigating to article.
+    Otherwise, proxy thinks client hasn't logged in yet.
+
+    Why a proxy isn't continuously logged in is beyond my
+    area of expertise.
+
+    We must first autologin, and only then we can navigate
+    to the article.
+*/
+
+let simpleRedirects = [{
+    host: "www.mediapart.fr",
+    autologin: "/licence"
+}, {
+    host: "www.arretsurimages.net",
+    autologin: "/autologin.php"
+}]
+
+let simpleRedirectHost = simpleRedirects.filter(element => element.host == host);
+
+if (simpleRedirectHost.length == 1) {
+    //window.location.replace(redirectHost + simpleRedirectHost.host + simpleRedirectHost.autologin);
+
+    // Now we need to navigate to the URL using the Tabs API (so that we can tell when the user has logged in)
+    browser.tabs.query({ currentWindow: true, active: true }).then((result)=>{ // We ask for the tab that is currently active in the window that is currently active
+        let current_tab_id = result[0].id; // We get its ID
+        browser.tabs.update(current_tab_id, {url: redirectHost + simpleRedirectHost.host + simpleRedirectHost.autologin}).then(()=>{ // We set the tab's url to the login page
+            let listener = (listener_tab_id, changeInfo)=> // we define a listener that is executed when an event is triggered in a tab
+                    {
+                        if ((listener_tab_id == current_tab_id) && changeInfo.url) //if the tab in which the event was triggered is the current tab and the change to the tab was its url
+                        {
+                            browser.tabs.onUpdated.removeListener(this); //we stop listening for updates
+                            browser.tabs.update(current_tab_id, {url: window.location.host + path}); //we redirect to the article
+                        }
+                    }
+            );
+            browser.tabs.onUpdated.addListener(listener); //we start listening for updates to tabs
+        },(error)=>{console.log(error)}; 
+    }, (error)=>{console.log(error)}); 
+
 }
 
 function removeQueryString(url) {


### PR DESCRIPTION
Bonjour,

Je pense avoir géré le problème avec Médiapart et Arrêt sur Images qui ne se connectent pas automatiquement.

## Détail technique

### Avant

La solution précédente (et actuellement en production) se base sur l'injection d'un script JS sur la page même sur les pages mediapart.fr et arretsurimages.net. Ce script obtient l'URL de la page actuelle, vérifie si c'est dans la liste de domaines pris en charge, et redirige vers la page de connexion de la BNF avec les paramètres ?login=[page du site ou de l'article], qui par la suite envoit vers la page de cet article même.

Le script intervient une seule fois - quand l'utilisateur va sur mediapart.fr ou arretsurimages.net.

### Problème

La redirection entre la page de connexion de la BNF et le proxy du site se fait, mais pour l'utilisateur, la page s'affiche comme n'étant pas connectée sur le compte abonné.

### Solution

Il faut se connecter sur le site vers lequel on veut naviguer - en allant sur une page spéciale dans un premier temps.

EasyBNF nous envoit vers le "autologin" directement: d'un côté, c'est mediapart.fr/licence (https://bnf.idm.oclc.org/login?url=http://www.mediapart.fr/licence) et et de l'autre, c'est arretsurimages.net/autologin.php (https://bnf.idm.oclc.org/login?url=http://www.arretsurimages.net/autologin.php).

### Maintenant

La solution précédente ne permet pas de tenir compte des changements de page sur un même fil d'execution - c'est normal, ce n'est pas un script en arrièreplan.

Ma solution met le script en arrièreplan, avec les permissions uniquement sur les sites d'authentification de la BNF, l'onglet actif et les permissions uniquement sur mediapart.fr et arretsurimages.net.

Elle utilise l'API "Tabs" de Firefox pour intéragir avec l'onglet.  https://developer.mozilla.org/fr/docs/Mozilla/Add-ons/WebExtensions/API/tabs

Ah, et j'ai rajouté des commentaires en anglais dans le script.

Maintenant, le processus pour rejoindre une page est le suivant:

*si la personne essaie de joindre la page principale*
[page] -> [page de connexion vers l'autologin] -> [autologin] -> [page initiale]

*si la personne essaie de joindre un article*
[page] -> [page de connexion vers l'autologin] -> [autologin] -> [page initiale] -> [article voulu]

La solution a été codée avec le même esprit que la précédente : ouvrir la possibilité à rajouter plus de domaines

### Cas de test

J'ai testé les six situations suivantes, sans problèmes de mon côté, et j'invite de plein coeur à refaire mes tests:

- déconnectée, je clique sur un lien m'envoit vers un article
- connectée, je clique sur un lien qui m'envoit vers un article
- déconnectée, je tape le nom de domaine d'un domaine pris en charge
- connectée, je tape le nom de domaine d'un domaine pris en charge
- déconnectée, je tape le nom de domaine d'un domaine pas pris en charge
- connectée, je tape le nom de domaine d'un domaine pas pris en charge

Je reste à disposition si quelque chose n'est pas claire, merci pour ton attention !
